### PR TITLE
Add portfolio for Makechi Eric

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,6 +409,7 @@ Hopefully this repo can serve as a source of inspiration for your portfolio!
 - [Mads Hougesen](https://mhouge.dk)
 - [Maduakor Emmanuel](https://emmajs.vercel.app)
 - [Mahmoud AlSharif](https://malsharif.me)
+- [Makechi Eric](https://love-makechi.web.app)
 - [Malik Muhammad Safwan](https://maliksafwan.netlify.app)
 - [Marc Backes](http://marc.dev)
 - [Marcos Aguayo](https://marcosaguayo.com)


### PR DESCRIPTION
### Add portfolio for Makechi Eric

This PR adds a new entry to the list of developer portfolios, featuring Makechi Eric's personal portfolio website.

The portfolio link has been added alphabetically to the existing list. The link directs to Makechi Eric's personal website showcasing his projects and skills.

Adding personal portfolios helps in showcasing individual contributions and increasing visibility for developers.

Related to Issue #42.
